### PR TITLE
feat: coq icon

### DIFF
--- a/icons/coq.svg
+++ b/icons/coq.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 26.458 26.458">
+<style>:root {--ctp-rosewater: #f5e0dc;--ctp-flamingo: #f2cdcd;--ctp-pink: #f5c2e7;--ctp-mauve: #cba6f7;--ctp-red: #f38ba8;--ctp-maroon: #eba0ac;--ctp-peach: #fab387;--ctp-yellow: #f9e2af;--ctp-green: #a6e3a1;--ctp-teal: #94e2d5;--ctp-sky: #89dceb;--ctp-sapphire: #74c7ec;--ctp-blue: #89b4fa;--ctp-lavender: #b4befe;--ctp-text: #cdd6f4;--ctp-overlay1: #7f849c;}</style>
+    <g fill="none" stroke-linecap="round" stroke-width="1.26657">
+        <path stroke="var(--ctp-yellow)" d="m8.246 8.248-1.28.996s-.453.093 1.652-.108c.68 1.007 2.604 3.462.642 4.891-6.54 3.534-2.34 1.93 1.599 5.878.541.543-2.005 3.142-2.005 3.142l.027 1.68 6.58.027-.123-2.105c-.047-.815-1.388-.82-.856-2.814.193-.723.686-2.546 1.906-2.792-.296-.692-.279-1.285.078-1.526 1.396-.945 1.555 1.18-1.527 3.293 16.252-1.721 3.856-19.315-1.882-5.361-.73-.396-.395-7.368-1.257-7.052" transform="translate(-1.197 -.023)"/>
+        <path stroke="var(--ctp-peach)" stroke-linejoin="round" d="M8.457 7.949c-2.068-.307-3.85-3.18-.115-5.478 3.973-2.444 10.825 1.894 5.995 5.843-.687.562-.807-4.555-5.88-.365Z" transform="translate(-1.197 -.023)"/>
+    </g>
+</svg>

--- a/src/associations/extensions.ts
+++ b/src/associations/extensions.ts
@@ -27,6 +27,7 @@ export const extensions: IconMap = {
   clojure: ['clj', 'cljs', 'cljc'],
   cmake: ['cmake'],
   coffeescript: ['coffee', 'cson', 'iced'],
+  coq: ['g', 'v'],
   cpp: ['cc', 'cpp', 'cxx', 'c++', 'cp', 'mm', 'mii', 'ii'],
   csharp: ['cs', 'csx'],
   csv: ['csv', 'tsv', 'psv'],

--- a/src/associations/languages.ts
+++ b/src/associations/languages.ts
@@ -7,6 +7,7 @@ export const languages: IconMap = {
   c: ['c', 'objective-c', 'objective-cpp'],
   clojure: ['clojure'],
   coffeescript: ['coffeescript'],
+  coq: ['coq'],
   cpp: ['cpp'],
   csharp: ['csharp'],
   css: ['css', 'less', 'postcss'],

--- a/src/icons/coq.svg
+++ b/src/icons/coq.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="100"
+   height="100"
+   viewBox="0 0 26.458333 26.458334"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
+   sodipodi:docname="coq.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="2.932688"
+     inkscape:cx="33.757427"
+     inkscape:cy="19.94757"
+     inkscape:window-width="1920"
+     inkscape:window-height="1021"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g1"
+       transform="translate(-1.1973034,-0.02255717)">
+      <path
+         style="fill:none;stroke:#e5c890;stroke-width:1.26657;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1"
+         d="M 8.2455432,8.2482293 6.9661416,9.2441731 c 0,0 -0.453336,0.092776 1.6523422,-0.1083442 0.6799249,1.0069631 2.6034392,3.4624671 0.6419807,4.8912291 -6.5398977,3.534313 -2.3400671,1.929603 1.5981645,5.878 0.541395,0.542798 -2.0044792,3.142163 -2.0044792,3.142163 l 0.027125,1.679425 6.5803542,0.02712 -0.123152,-2.104875 c -0.0477,-0.815142 -1.388168,-0.819047 -0.856083,-2.813848 0.192782,-0.722735 0.685582,-2.546475 1.905825,-2.791598 -0.296652,-0.692052 -0.279183,-1.285101 0.07758,-1.526541 1.396475,-0.945059 1.555365,1.180863 -1.526762,3.293465 16.252409,-1.721845 3.856275,-19.31554773 -1.881622,-5.361695 -0.730999,-0.395432 -0.395813,-7.3674193 -1.257732,-7.0513792"
+         id="path3"
+         sodipodi:nodetypes="ccsscccssscsccc" />
+      <path
+         style="fill:none;stroke:#ef9f76;stroke-width:1.26657;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+         d="M 8.4573026,7.9487284 C 6.3886926,7.6422614 4.6064955,4.7686214 8.3423722,2.4707417 12.315151,0.02715394 19.167406,4.364844 14.336709,8.3142849 13.650251,8.8755218 13.529598,3.7593153 8.4573026,7.9487284 Z"
+         id="path2"
+         sodipodi:nodetypes="cssc" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Added an icon for coq source files (vernacular: `.v` and gallina: `.g`).
Here's what it looks like:
![image](https://github.com/catppuccin/vscode-icons/assets/53104608/130c4711-e8a4-4d78-b9ef-313ea2924e80)

![image](https://github.com/catppuccin/vscode-icons/assets/53104608/8a1787d3-b41c-45bd-a7af-0811001e77d2)
