### PR TITLE
chore(nix): add `shell.nix`

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,14 @@
+{pkgs ? import <nixpkgs> {}}: let
+  inherit (pkgs.stdenv) isLinux;
+in
+  pkgs.mkShell {
+    buildInputs = with pkgs; [
+      chromium
+      nodejs
+      yarn
+    ];
+    PUPPETEER_EXECUTABLE_PATH =
+      if isLinux
+      then "${pkgs.chromium}/bin/chromium"
+      else "";
+  }


### PR DESCRIPTION
Setting up `puppeteer` on NixOS requires one extra step, so this should help Nix users :slightly_smiling_face: 