### PR TITLE
chore: annotate html in `extensions.ts`

### DIFF
--- a/src/associations/extensions.ts
+++ b/src/associations/extensions.ts
@@ -99,7 +99,7 @@ export const extensions: IconMap = {
   haskell: ['hs'],
   haxe: ['hx', 'hxml'],
   hpp: ['hh', 'hpp', 'hxx', 'h++', 'hp', 'tcc', 'inl'],
-  html: ['htm', 'xhtml', 'html_vm', 'asp'],
+  html: ['htm', 'html', 'xhtml', 'html_vm', 'asp'],
   http: ['http', 'rest'],
   image: [
     'png',


### PR DESCRIPTION
This PR adds the `.html` file extension to `extensions.ts`, as some ports may not be able to use the `languages.ts` file.