### PR TITLE
chore: add trailing comma

### DIFF
--- a/src/associations/files.ts
+++ b/src/associations/files.ts
@@ -523,7 +523,7 @@ export const files: IconMap = {
     'uno.config.js',
     'uno.config.ts',
     'unocss.config.js',
-    'unocss.config.ts'
+    'unocss.config.ts',
   ],
   v: ['vpkg.json', 'v.mod'],
   vercel: ['vercel.json', 'now.json'],


### PR DESCRIPTION
The latest release CI workflow failed because a trailing comma was missing -> https://github.com/catppuccin/vscode-icons/actions/runs/7379613771/job/20076084360

This PR adds the missing trailing comma.