### PR TITLE
feat(nix_flake): add `viewBox`

### DIFF
--- a/icons/nix_flake_lock.svg
+++ b/icons/nix_flake_lock.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round" clip-rule="evenodd">
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round" clip-rule="evenodd" viewBox="0 0 100 100">
 <style>:root {--ctp-rosewater: #f5e0dc;--ctp-flamingo: #f2cdcd;--ctp-pink: #f5c2e7;--ctp-mauve: #cba6f7;--ctp-red: #f38ba8;--ctp-maroon: #eba0ac;--ctp-peach: #fab387;--ctp-yellow: #f9e2af;--ctp-green: #a6e3a1;--ctp-teal: #94e2d5;--ctp-sky: #89dceb;--ctp-sapphire: #74c7ec;--ctp-blue: #89b4fa;--ctp-lavender: #b4befe;--ctp-text: #cdd6f4;--ctp-overlay1: #7f849c;}</style>
     <g fill="none" stroke-width="5">
         <path stroke="var(--ctp-sapphire)" d="M2.584 49.998h21.757m8.211-13.804L13.574 68.805"/>


### PR DESCRIPTION
This allows to use `width` and `height` to be used to scale the icon. 

REF: https://github.com/catppuccin/jetbrains-icons/issues/17