### PR TITLE
feat: shortcut icons

### DIFF
--- a/icons/css-variables/shortcut.svg
+++ b/icons/css-variables/shortcut.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 14" width="16" height="14">
+	<rect width="14" height="8" x="1" y="1" stroke="var(--vscode-ctp-text)" stroke-linejoin="round" rx="1" />
+	<path stroke="var(--vscode-ctp-text)" stroke-linecap="round" stroke-linejoin="round" d="M2 13h12M6 7l4-4m0 0H8m2 0v2M7 9h2v4H7V9Z" />
+</svg>

--- a/icons/frappe/shortcut.svg
+++ b/icons/frappe/shortcut.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 14" width="16" height="14">
+	<rect width="14" height="8" x="1" y="1" stroke="#c6d0f5" stroke-linejoin="round" rx="1" />
+	<path stroke="#c6d0f5" stroke-linecap="round" stroke-linejoin="round" d="M2 13h12M6 7l4-4m0 0H8m2 0v2M7 9h2v4H7V9Z" />
+</svg>

--- a/icons/latte/shortcut.svg
+++ b/icons/latte/shortcut.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="14" viewBox="0 0 16 14">
+	<g fill="none" stroke="#4c4f69" stroke-linejoin="round">
+		<rect width="14" height="8" x="1" y="1" rx="1" />
+		<path stroke-linecap="round" d="M2 13h12M6 7l4-4m0 0H8m2 0v2M7 9h2v4H7V9Z" />
+	</g>
+</svg>

--- a/icons/macchiato/shortcut.svg
+++ b/icons/macchiato/shortcut.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 14" width="16" height="14">
+	<rect width="14" height="8" x="1" y="1" stroke="#cad3f5" stroke-linejoin="round" rx="1" />
+	<path stroke="#cad3f5" stroke-linecap="round" stroke-linejoin="round" d="M2 13h12M6 7l4-4m0 0H8m2 0v2M7 9h2v4H7V9Z" />
+</svg>

--- a/icons/mocha/shortcut.svg
+++ b/icons/mocha/shortcut.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 14" width="16" height="14">
+	<rect width="14" height="8" x="1" y="1" stroke="#cdd6f4" stroke-linejoin="round" rx="1" />
+	<path stroke="#cdd6f4" stroke-linecap="round" stroke-linejoin="round" d="M2 13h12M6 7l4-4m0 0H8m2 0v2M7 9h2v4H7V9Z" />
+</svg>

--- a/src/defaults/fileIcons.ts
+++ b/src/defaults/fileIcons.ts
@@ -2024,6 +2024,9 @@ const fileIcons: Record<string, {
       'wgsl',
     ],
   },
+  'shortcut': {
+    fileExtensions: ['lnk', 'webloc', 'alias', 'desktop'],
+  },
   'sketch': {
     fileExtensions: ['sketch'],
   },


### PR DESCRIPTION
added a icon for shortcut icons for different operating systems.
i based the design on windows having a little arrow, and linux shortcuts being a .desktop file.
so i combined them into a monitor with a arrow.

list of extensions:
macos:
- alias
- webloc

windows:
- lnk

linux:
- desktop