### PR TITLE
feat: vital icons

### DIFF
--- a/icons/css-variables/vital.svg
+++ b/icons/css-variables/vital.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16" width="16" height="16">
+	<path stroke="var(--vscode-ctp-text)" stroke-linecap="round" stroke-linejoin="round" d="M8 15S5 6.5 1 4c1 .2 3.3.5 4.5.5 1 .5 2.5 3 2.5 4 0-1 1.5-3.5 2.5-4A31 31 0 0 0 15 4c-4 2.5-7 11-7 11Z" />
+	<path stroke="var(--vscode-ctp-mauve)" stroke-linecap="round" stroke-linejoin="round" d="M3.4 2.6S5 1 7.7 1C10.4 1 12 2.6 12 2.6m-10.9 4S.5 8.7 2 11a6 6 0 0 0 3.4 3m4.6 0s2.2-.6 3.5-3c1.4-2.2.8-4.5.8-4.5" />
+</svg>

--- a/icons/frappe/vital.svg
+++ b/icons/frappe/vital.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16" width="16" height="16">
+	<path stroke="#c6d0f5" stroke-linecap="round" stroke-linejoin="round" d="M8 15S5 6.5 1 4c1 .2 3.3.5 4.5.5 1 .5 2.5 3 2.5 4 0-1 1.5-3.5 2.5-4A31 31 0 0 0 15 4c-4 2.5-7 11-7 11Z" />
+	<path stroke="#ca9ee6" stroke-linecap="round" stroke-linejoin="round" d="M3.4 2.6S5 1 7.7 1C10.4 1 12 2.6 12 2.6m-10.9 4S.5 8.7 2 11a6 6 0 0 0 3.4 3m4.6 0s2.2-.6 3.5-3c1.4-2.2.8-4.5.8-4.5" />
+</svg>

--- a/icons/latte/vital.svg
+++ b/icons/latte/vital.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+	<g fill="none" stroke-linecap="round" stroke-linejoin="round">
+		<path stroke="#4c4f69" d="M8 15S5 6.5 1 4c1 .2 3.3.5 4.5.5 1 .5 2.5 3 2.5 4 0-1 1.5-3.5 2.5-4A31 31 0 0 0 15 4c-4 2.5-7 11-7 11Z" />
+		<path stroke="#8839ef" d="M3.4 2.6S5 1 7.7 1C10.4 1 12 2.6 12 2.6m-10.9 4S.5 8.7 2 11a6 6 0 0 0 3.4 3m4.6 0s2.2-.6 3.5-3c1.4-2.2.8-4.5.8-4.5" />
+	</g>
+</svg>

--- a/icons/macchiato/vital.svg
+++ b/icons/macchiato/vital.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16" width="16" height="16">
+	<path stroke="#cad3f5" stroke-linecap="round" stroke-linejoin="round" d="M8 15S5 6.5 1 4c1 .2 3.3.5 4.5.5 1 .5 2.5 3 2.5 4 0-1 1.5-3.5 2.5-4A31 31 0 0 0 15 4c-4 2.5-7 11-7 11Z" />
+	<path stroke="#c6a0f6" stroke-linecap="round" stroke-linejoin="round" d="M3.4 2.6S5 1 7.7 1C10.4 1 12 2.6 12 2.6m-10.9 4S.5 8.7 2 11a6 6 0 0 0 3.4 3m4.6 0s2.2-.6 3.5-3c1.4-2.2.8-4.5.8-4.5" />
+</svg>

--- a/icons/mocha/vital.svg
+++ b/icons/mocha/vital.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16" width="16" height="16">
+	<path stroke="#cdd6f4" stroke-linecap="round" stroke-linejoin="round" d="M8 15S5 6.5 1 4c1 .2 3.3.5 4.5.5 1 .5 2.5 3 2.5 4 0-1 1.5-3.5 2.5-4A31 31 0 0 0 15 4c-4 2.5-7 11-7 11Z" />
+	<path stroke="#cba6f7" stroke-linecap="round" stroke-linejoin="round" d="M3.4 2.6S5 1 7.7 1C10.4 1 12 2.6 12 2.6m-10.9 4S.5 8.7 2 11a6 6 0 0 0 3.4 3m4.6 0s2.2-.6 3.5-3c1.4-2.2.8-4.5.8-4.5" />
+</svg>

--- a/src/defaults/fileIcons.ts
+++ b/src/defaults/fileIcons.ts
@@ -2401,6 +2401,16 @@ const fileIcons: Record<string, {
       'vcxproj.filters',
     ],
   },
+  'vital': {
+    fileExtensions: [
+      'vital',
+      'vitalbank',
+      'vitallfo',
+      'vitalskin',
+      'vitaltable',
+      'vitaltheme',
+    ],
+  },
   'vite': {
     fileNames: [
       'vite.config.js',


### PR DESCRIPTION
added icon for *files associated with [Vital](https://vital.audio/) synth.
<img src="https://vital.audio/images/vital_full_no_background.png" alt="vital logo" width=64>


\*
- themes
- lfos
- wavetables
- etc ...