### PR TITLE
chore: disable prettier for vscode users

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "prettier.enable": false
+}


### PR DESCRIPTION
The conflict between Prettier and ESLint Stylistic was causing a lot of errors!