### PR TITLE
refactor(scripts): pass OS path separator to `mkdtemp`

### DIFF
--- a/scripts/catwalk.ts
+++ b/scripts/catwalk.ts
@@ -3,9 +3,9 @@
  */
 
 import { exec } from 'node:child_process'
-import { mkdtemp, readdir, realpath, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { join, resolve, sep } from 'node:path'
 import { exit } from 'node:process'
 import { promisify } from 'node:util'
 import { type FlavorName, flavorEntries, flavors } from '@catppuccin/palette'
@@ -68,7 +68,7 @@ function generateHtml(flavor: FlavorName) {
 try {
   consola.info('Generating Catwalk preview...')
 
-  const tmp = await mkdtemp(join(await realpath(tmpdir())))
+  const tmp = await mkdtemp(join(tmpdir(), sep))
 
   const images = await Promise.all(flavorEntries.map(async ([flavor]) => {
     const htmlPath = join(tmp, `${flavor}.html`)

--- a/scripts/icons/preview.ts
+++ b/scripts/icons/preview.ts
@@ -2,9 +2,9 @@
  * Generates previews (.webp) for all flavors.
  */
 
-import { mkdtemp, readdir, realpath, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join, resolve } from 'node:path'
+import { join, resolve, sep } from 'node:path'
 import { type FlavorName, flavorEntries, flavors } from '@catppuccin/palette'
 import { consola } from 'consola'
 import { launch } from 'puppeteer'
@@ -86,7 +86,7 @@ try {
     `
   }
 
-  const tmp = await mkdtemp(join(await realpath(tmpdir())))
+  const tmp = await mkdtemp(join(tmpdir(), sep))
 
   await Promise.all(flavorEntries.map(async ([flavor]) => {
     const htmlPath = join(tmp, `${flavor}.html`)


### PR DESCRIPTION
The documentation states that:

> The fsPromises.mkdtemp() method will append the six randomly selected characters directly to the prefix string. For instance, given a directory /tmp, if the intention is to create a temporary directory within /tmp, the prefix must end with a trailing platform-specific path separator (require('node:path').sep).

This PR updates the arguments to `mkdtemp()` to take in the OS-specific path separator to fix the issues on my linux system. The directories are now created as shown below:

![image](https://github.com/user-attachments/assets/eb8f3228-10f4-444a-b6ef-7c9b4097e0fb)
