### PR TITLE
ci: add `previews.yml` to re-generate assets

### DIFF
--- a/.github/workflows/previews.yml
+++ b/.github/workflows/previews.yml
@@ -1,0 +1,56 @@
+name: Generate Previews
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'icons/**'
+      - scripts/icons/preview.ts
+      - scripts/catwalk.ts
+    tags-ignore: [v*]
+
+jobs:
+  generate-previews:
+    name: Generate Previews
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Install dependencies
+        run: pnpm i --frozen-lockfile
+
+      - name: Generate Flavor Previews
+        run: pnpm icons:preview
+
+      - name: Install catppuccin/catwalk
+        shell: bash
+        run: |
+          mkdir /tmp/catwalk
+          cd /tmp/catwalk
+          curl -LSs https://github.com/catppuccin/catwalk/releases/download/v1.3.2/catwalk-aarch64-apple-darwin -o catwalk
+          chmod +x catwalk
+          echo `pwd` >> $GITHUB_PATH
+
+      - name: Generate Catwalk Preview
+        run: pnpm catwalk
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: 'chore: re-generate previews'
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          signoff: false
+          branch: chore/re-generate-previews
+          delete-branch: true
+          title: 'chore: re-generate previews'

--- a/.github/workflows/previews.yml
+++ b/.github/workflows/previews.yml
@@ -39,7 +39,7 @@ jobs:
           cd /tmp/catwalk
           curl -LSs https://github.com/catppuccin/catwalk/releases/download/v1.3.2/catwalk-aarch64-apple-darwin -o catwalk
           chmod +x catwalk
-          echo `pwd` >> $GITHUB_PATH
+          echo $(pwd) >> $GITHUB_PATH
 
       - name: Generate Catwalk Preview
         run: pnpm catwalk

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 .pnpm-debug.log*
 *.vsix
 .DS_Store
+.cache

--- a/scripts/catwalk.ts
+++ b/scripts/catwalk.ts
@@ -74,7 +74,9 @@ try {
     const htmlPath = join(tmp, `${flavor}.html`)
     const screenshotPath = join(tmp, `${flavor}.png`)
     await writeFile(htmlPath, generateHtml(flavor))
-    const browser = await launch()
+    const browser = await launch({
+      args: ['--no-sandbox'],
+    })
     const page = await browser.newPage()
     await page.setViewport({
       height: 400,

--- a/scripts/icons/preview.ts
+++ b/scripts/icons/preview.ts
@@ -92,7 +92,9 @@ try {
     const htmlPath = join(tmp, `${flavor}.html`)
     const screenshotPath = join('assets', `${flavor}.webp`)
     await writeFile(htmlPath, generateHtml(flavor))
-    const browser = await launch()
+    const browser = await launch({
+      args: ['--no-sandbox'],
+    })
     const page = await browser.newPage()
     await page.goto(join('file:', htmlPath))
     await page.screenshot({


### PR DESCRIPTION
This PR comes from my frustration on the lack of good font rendering on Linux. 

I was trying to re-generate the previews to get them to match the existing previews. Unfortunately, Puppeteer seems to struggle with consistency across operating systems as highlighted in https://github.com/puppeteer/puppeteer/issues/661

I tried the solutions commented in the above issue but nothing seemed to work. Ultimately, I gave up and decided to try and see if we can make it a concern of the CI. I was finally successful and this PR adds a new workflow `previews.yml` that re-generates the individual flavour previews and the catwalk preview. 

You can view the output of a successful run in https://github.com/sgoudham/ci-playground/pull/10

**Limitations / Concerns:** 
- We're using the `macos-latest` runner which is basically the entire reason why the font rendering matches up with the existing previews.
- Telling pnpm to cache the directory results in an error where the chrome executable cannot be found. I tried setting the cache directory in the Puppeteer config file but it still failed and, honestly, I gave up after that.
- The pnpm scripts are not correctly outputting exit code 1 and failing the CI pipeline. I'm not too fussed about it since we know if it's failed if it's not raised a PR when we're expecting it to create one but this should be looked into.