### PR TITLE
build(package.json): add `--sequential` to `icons` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "icons:generate": "tsx scripts/icons/generate.ts",
     "icons:optimize": "tsx scripts/icons/optimize.ts",
     "icons:preview": "tsx scripts/icons/preview.ts",
-    "icons": "pnpm run '/^icons:.*/'",
+    "icons": "pnpm run --sequential '/^icons:.*/'",
     "integrity": "tsx scripts/integrity.ts",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
As mentioned in Discord, this (undocumented! but in `--help`) flag for `pnpm run` runs the scripts sequentially instead of in parallel. The scripts are ran as ordered in the package.json, so this now properly emulates the behavior of `pnpm run icons -a` before the refactor: runs generate, then optimize, then previews.