### PR TITLE
fix: add missing `postcss.config.{mts,mjs}` to defaults

### DIFF
--- a/src/defaults/fileIcons.ts
+++ b/src/defaults/fileIcons.ts
@@ -1708,8 +1708,10 @@ const fileIcons: Record<string, {
     fileNames: [
       'postcss.config.js',
       'postcss.config.cjs',
+      'postcss.config.mjs',
       'postcss.config.ts',
       'postcss.config.cts',
+      'postcss.config.mts',
       '.postcssrc.js',
       '.postcssrc.cjs',
       '.postcssrc.ts',


### PR DESCRIPTION
two extensions where missing in the defaults for postcss config file, so i added them 