### PR TITLE
fix(associations): add `.cts` and `.mts` extensions for eslint

### DIFF
--- a/src/defaults/fileIcons.ts
+++ b/src/defaults/fileIcons.ts
@@ -787,6 +787,8 @@ const fileIcons: Record<string, {
       'eslint.config.cjs',
       'eslint.config.mjs',
       'eslint.config.ts',
+      'eslint.config.cts',
+      'eslint.config.mts',
     ],
   },
   'eslint-ignore': {


### PR DESCRIPTION
added associations for the missing typescript extensions `.mts` and `.cts`, both are mentioned in [the docs](https://eslint.org/docs/latest/use/configure/configuration-files)
