### PR TITLE
fix(associations): add common/modules and `.vuerc` extensions for vue

### DIFF
--- a/src/defaults/fileIcons.ts
+++ b/src/defaults/fileIcons.ts
@@ -787,6 +787,8 @@ const fileIcons: Record<string, {
       'eslint.config.cjs',
       'eslint.config.mjs',
       'eslint.config.ts',
+      'eslint.config.cts',
+      'eslint.config.mts',
     ],
   },
   'eslint-ignore': {
@@ -2531,13 +2533,19 @@ const fileIcons: Record<string, {
   'vue-config': {
     fileNames: [
       'vue.config.js',
+      'vue.config.cjs',
+      'vue.config.mjs',
       'vue.config.ts',
+      'vue.config.cts',
+      'vue.config.mts',
+      
+      '.vuerc'
     ],
   },
   'web-assembly': {
     fileExtensions: [
       'wat',
-      'wasm',
+      'wasm', 
     ],
   },
   'webpack': {


### PR DESCRIPTION
add vue legacy config file `.vuerc`, was mentioned in [vue-cli docs](https://cli.vuejs.org/config/) 