### PR TITLE
fix(associations): add common extensions and `.vuerc` for vue

### DIFF
--- a/src/defaults/fileIcons.ts
+++ b/src/defaults/fileIcons.ts
@@ -2531,7 +2531,12 @@ const fileIcons: Record<string, {
   'vue-config': {
     fileNames: [
       'vue.config.js',
+      'vue.config.cjs',
+      'vue.config.mjs',
       'vue.config.ts',
+      'vue.config.cts',
+      'vue.config.mts',
+      '.vuerc',
     ],
   },
   'web-assembly': {


### PR DESCRIPTION
add vue legacy config file .vuerc, was mentioned in [vue-cli docs](https://cli.vuejs.org/config/)