### PR TITLE
feat(associations): add `database` icon for `.dat` files

### DIFF
--- a/src/defaults/fileIcons.ts
+++ b/src/defaults/fileIcons.ts
@@ -513,6 +513,7 @@ const fileIcons: Record<string, {
       'psql',
       'db',
       'db3',
+      'dat',
     ],
   },
   'deno': {


### PR DESCRIPTION
https://github.com/NixOS/nixos-search/blob/main/frontend/registry.dat
https://www.reddit.com/r/MacOS/comments/14gfk92/what_is_a_dat_file/
Seems like an appropriate icon for this file type.