### PR TITLE
feat: add benchmark icon

### DIFF
--- a/icons/css-variables/benchmark.svg
+++ b/icons/css-variables/benchmark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+	<path fill="none" stroke="var(--vscode-ctp-peach)" stroke-linecap="round" stroke-linejoin="round" d="m 14.562407,13.624879 c 0.635619,-1.100617 0.937494,-2.386859 0.937494,-3.7499726 A 7.4999463,7.4999463 0 1 0 1.5031254,13.624879 m 5.5593354,0 3.7499732,-4.6874663" />
+</svg>

--- a/icons/frappe/benchmark.svg
+++ b/icons/frappe/benchmark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+	<path fill="none" stroke="#ef9f76" stroke-linecap="round" stroke-linejoin="round" d="m 14.562407,13.624879 c 0.635619,-1.100617 0.937494,-2.386859 0.937494,-3.7499726 A 7.4999463,7.4999463 0 1 0 1.5031254,13.624879 m 5.5593354,0 3.7499732,-4.6874663" />
+</svg>

--- a/icons/latte/benchmark.svg
+++ b/icons/latte/benchmark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+	<path fill="none" stroke="#fe640b" stroke-linecap="round" stroke-linejoin="round" d="m 14.562407,13.624879 c 0.635619,-1.100617 0.937494,-2.386859 0.937494,-3.7499726 A 7.4999463,7.4999463 0 1 0 1.5031254,13.624879 m 5.5593354,0 3.7499732,-4.6874663" />
+</svg>

--- a/icons/macchiato/benchmark.svg
+++ b/icons/macchiato/benchmark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+	<path fill="none" stroke="#f5a97f" stroke-linecap="round" stroke-linejoin="round" d="m 14.562407,13.624879 c 0.635619,-1.100617 0.937494,-2.386859 0.937494,-3.7499726 A 7.4999463,7.4999463 0 1 0 1.5031254,13.624879 m 5.5593354,0 3.7499732,-4.6874663" />
+</svg>

--- a/icons/mocha/benchmark.svg
+++ b/icons/mocha/benchmark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+	<path fill="none" stroke="#fab387" stroke-linecap="round" stroke-linejoin="round" d="m 14.562407,13.624879 c 0.635619,-1.100617 0.937494,-2.386859 0.937494,-3.7499726 A 7.4999463,7.4999463 0 1 0 1.5031254,13.624879 m 5.5593354,0 3.7499732,-4.6874663" />
+</svg>

--- a/src/defaults/fileIcons.ts
+++ b/src/defaults/fileIcons.ts
@@ -236,6 +236,16 @@ const fileIcons: Record<string, {
     fileExtensions: ['bzl', 'bazel'],
     fileNames: ['.bazelrc'],
   },
+  'benchmark': {
+    fileNames: [
+      'benchmark.md',
+      'benchmark.rst',
+      'benchmark.txt',
+      'benchmarks.md',
+      'benchmarks.rst',
+      'benchmarks.txt',
+    ],
+  },
   'binary': {
     languageIds: ['code-text-binary'],
     fileExtensions: ['bin'],


### PR DESCRIPTION
I took the benchmark/speed dial thing from the benchmark folder icon, and separated it out.