### PR TITLE
Add Hardhat Icon to Catppuccin Icon Library

### DIFF
--- a/icons/frappe/hardhat-icon-frappe.svg
+++ b/icons/frappe/hardhat-icon-frappe.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <path d="M1.5 11.5h13M2.5 11.5v-4a5.5 5.5 0 0111 0v4M5.5 4.5a5.5 5.5 0 015 0M8 2v3M5.5 2.5l1 2M10.5 2.5l-1 2" stroke="#e5c890" stroke-width="1" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/icons/latte/hardhat-icon-latte.svg
+++ b/icons/latte/hardhat-icon-latte.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <path d="M1.5 11.5h13M2.5 11.5v-4a5.5 5.5 0 0111 0v4M5.5 4.5a5.5 5.5 0 015 0M8 2v3M5.5 2.5l1 2M10.5 2.5l-1 2" stroke="#df8e1d" stroke-width="1" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/icons/macchiato/hardhat-icon-macchiato.svg
+++ b/icons/macchiato/hardhat-icon-macchiato.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <path d="M1.5 11.5h13M2.5 11.5v-4a5.5 5.5 0 0111 0v4M5.5 4.5a5.5 5.5 0 015 0M8 2v3M5.5 2.5l1 2M10.5 2.5l-1 2" stroke="#eed49f" stroke-width="1" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/icons/mocha/hardhat-icon-mocha.svg
+++ b/icons/mocha/hardhat-icon-mocha.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+  <path d="M1.5 11.5h13M2.5 11.5v-4a5.5 5.5 0 0111 0v4M5.5 4.5a5.5 5.5 0 015 0M8 2v3M5.5 2.5l1 2M10.5 2.5l-1 2" stroke="#f9e2af" stroke-width="1" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>


### PR DESCRIPTION
Fixes #276
This PR adds the Hardhat icon to the Catppuccin icon library. Hardhat is a popular Ethereum development environment, and this icon will be useful for users who want to represent Hardhat in their Catppuccin-themed setups.

- Added Hardhat icon SVG for the Frappe theme
- Added Hardhat icon SVG for the Mocha theme
- Added Hardhat icon SVG for the Latte theme
- Added Hardhat icon SVG for the Macchiato theme