### PR TITLE
feat: enable razor icon for `.razor` extension in `jetbrains-icons`

### DIFF
--- a/src/defaults/fileIcons.ts
+++ b/src/defaults/fileIcons.ts
@@ -1918,6 +1918,7 @@ const fileIcons: FileIcons = {
     fileExtensions: [
       'cshtml',
       'vbhtml',
+      'razor',
     ],
   },
   'readme': {


### PR DESCRIPTION
Small change to enable `.razor` extension files to show the already existing razor file icon in `jetbrains-icons`. The `.razor` extension is used in Blazor projects.

Before:
![image](https://github.com/user-attachments/assets/9b1a9820-480a-46f4-98e0-24f6ede8d78f)

After:
![image](https://github.com/user-attachments/assets/aacd9f5b-308a-48a8-8795-ef2ccd4e9701)

Let me know if I need to do anything to bump the change onto `jetbrains-icons` :)

