### PR TITLE
feat(associations): add `xaml` icon for `.axaml` files

### DIFF
--- a/src/defaults/fileIcons.ts
+++ b/src/defaults/fileIcons.ts
@@ -2797,7 +2797,10 @@ const fileIcons: FileIcons = {
     ],
   },
   'xaml': {
-    fileExtensions: ['xaml'],
+    fileExtensions: [
+      'xaml',
+      'axaml',
+    ],
   },
   'xmake': {
     fileNames: ['xmake.lua'],


### PR DESCRIPTION
> "The file extension for XAML files used elsewhere is .xaml but due to technical issues integrating with Visual Studio, Avalonia UI uses its own .axaml extension - 'Avalonia XAML'."

ref: https://docs.avaloniaui.net/docs/basics/user-interface/introduction-to-xaml#axaml-file-extension