### PR TITLE
feat: add juce icon

### DIFF
--- a/icons/css-variables/juce.svg
+++ b/icons/css-variables/juce.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 16 16" width="16" height="16">
+	<path stroke="var(--vscode-ctp-mauve)" stroke-linecap="round" stroke-linejoin="round" d="M9 3c-.5-.5-1.5-.5-2 0s.5 1.5 1 2.5c.5-1 1.5-2 1-2.5Z" />
+	<path stroke="var(--vscode-ctp-yellow)" stroke-linecap="round" stroke-linejoin="round" d="M9 13c-.5.5-1.5.5-2 0s.5-1.5 1-2.5c.5 1 1.5 2 1 2.5Z" />
+	<path stroke="var(--vscode-ctp-teal)" stroke-linecap="round" stroke-linejoin="round" d="M3 7c-.5.5-.5 1.5 0 2s1.5-.5 2.5-1c-1-.5-2-1.5-2.5-1Z" />
+	<path stroke="var(--vscode-ctp-peach)" stroke-linecap="round" stroke-linejoin="round" d="M13 7c.5.5.5 1.5 0 2s-1.5-.5-2.5-1c1-.5 2-1.5 2.5-1Z" />
+	<path stroke="var(--vscode-ctp-blue)" stroke-linecap="round" stroke-linejoin="round" d="M5.2 3.8c-.7 0-1.4.7-1.4 1.4s1.4.7 2.4 1c-.3-1-.3-2.4-1-2.4Z" />
+	<path stroke="var(--vscode-ctp-peach)" stroke-linecap="round" stroke-linejoin="round" d="M12.2 10.8c0 .7-.7 1.4-1.4 1.4s-.7-1.4-1-2.4c1 .3 2.4.3 2.4 1Z" />
+	<path stroke="var(--vscode-ctp-red)" stroke-linecap="round" stroke-linejoin="round" d="M12.2 5.2c0-.7-.7-1.4-1.4-1.4s-.7 1.4-1 2.4c1-.3 2.4-.3 2.4-1Z" />
+	<path stroke="var(--vscode-ctp-green)" stroke-linecap="round" stroke-linejoin="round" d="M5.2 12.2c-.7 0-1.4-.7-1.4-1.4s1.4-.7 2.4-1c-.3 1-.3 2.4-1 2.4Z" />
+	<circle cx="8" cy="8" r="7" stroke="var(--vscode-ctp-green)" />
+	<path stroke="var(--vscode-ctp-text)" stroke-linejoin="round" d="M7.9 7.9h.2v.2h-.2z" />
+</svg>

--- a/icons/frappe/juce.svg
+++ b/icons/frappe/juce.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+	<g fill="none">
+		<path stroke="#ca9ee6" stroke-linecap="round" stroke-linejoin="round" d="M9 3c-.5-.5-1.5-.5-2 0s.5 1.5 1 2.5c.5-1 1.5-2 1-2.5Z" />
+		<path stroke="#e5c890" stroke-linecap="round" stroke-linejoin="round" d="M9 13c-.5.5-1.5.5-2 0s.5-1.5 1-2.5c.5 1 1.5 2 1 2.5Z" />
+		<path stroke="#81c8be" stroke-linecap="round" stroke-linejoin="round" d="M3 7c-.5.5-.5 1.5 0 2s1.5-.5 2.5-1c-1-.5-2-1.5-2.5-1Z" />
+		<path stroke="#ef9f76" stroke-linecap="round" stroke-linejoin="round" d="M13 7c.5.5.5 1.5 0 2s-1.5-.5-2.5-1c1-.5 2-1.5 2.5-1Z" />
+		<path stroke="#8caaee" stroke-linecap="round" stroke-linejoin="round" d="M5.2 3.8c-.7 0-1.4.7-1.4 1.4s1.4.7 2.4 1c-.3-1-.3-2.4-1-2.4Z" />
+		<path stroke="#ef9f76" stroke-linecap="round" stroke-linejoin="round" d="M12.2 10.8c0 .7-.7 1.4-1.4 1.4s-.7-1.4-1-2.4c1 .3 2.4.3 2.4 1Z" />
+		<path stroke="#e78284" stroke-linecap="round" stroke-linejoin="round" d="M12.2 5.2c0-.7-.7-1.4-1.4-1.4s-.7 1.4-1 2.4c1-.3 2.4-.3 2.4-1Z" />
+		<path stroke="#a6d189" stroke-linecap="round" stroke-linejoin="round" d="M5.2 12.2c-.7 0-1.4-.7-1.4-1.4s1.4-.7 2.4-1c-.3 1-.3 2.4-1 2.4Z" />
+		<circle cx="8" cy="8" r="7" stroke="#a6d189" />
+		<path stroke="#c6d0f5" stroke-linejoin="round" d="M7.9 7.9h.2v.2h-.2z" />
+	</g>
+</svg>

--- a/icons/latte/juce.svg
+++ b/icons/latte/juce.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+	<g fill="none">
+		<path stroke="#8839ef" stroke-linecap="round" stroke-linejoin="round" d="M9 3c-.5-.5-1.5-.5-2 0s.5 1.5 1 2.5c.5-1 1.5-2 1-2.5Z" />
+		<path stroke="#df8e1d" stroke-linecap="round" stroke-linejoin="round" d="M9 13c-.5.5-1.5.5-2 0s.5-1.5 1-2.5c.5 1 1.5 2 1 2.5Z" />
+		<path stroke="#179299" stroke-linecap="round" stroke-linejoin="round" d="M3 7c-.5.5-.5 1.5 0 2s1.5-.5 2.5-1c-1-.5-2-1.5-2.5-1Z" />
+		<path stroke="#fe640b" stroke-linecap="round" stroke-linejoin="round" d="M13 7c.5.5.5 1.5 0 2s-1.5-.5-2.5-1c1-.5 2-1.5 2.5-1Z" />
+		<path stroke="#1e66f5" stroke-linecap="round" stroke-linejoin="round" d="M5.2 3.8c-.7 0-1.4.7-1.4 1.4s1.4.7 2.4 1c-.3-1-.3-2.4-1-2.4Z" />
+		<path stroke="#fe640b" stroke-linecap="round" stroke-linejoin="round" d="M12.2 10.8c0 .7-.7 1.4-1.4 1.4s-.7-1.4-1-2.4c1 .3 2.4.3 2.4 1Z" />
+		<path stroke="#d20f39" stroke-linecap="round" stroke-linejoin="round" d="M12.2 5.2c0-.7-.7-1.4-1.4-1.4s-.7 1.4-1 2.4c1-.3 2.4-.3 2.4-1Z" />
+		<path stroke="#40a02b" stroke-linecap="round" stroke-linejoin="round" d="M5.2 12.2c-.7 0-1.4-.7-1.4-1.4s1.4-.7 2.4-1c-.3 1-.3 2.4-1 2.4Z" />
+		<circle cx="8" cy="8" r="7" stroke="#40a02b" />
+		<path stroke="#4c4f69" stroke-linejoin="round" d="M7.9 7.9h.2v.2h-.2z" />
+	</g>
+</svg>

--- a/icons/macchiato/juce.svg
+++ b/icons/macchiato/juce.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+	<g fill="none">
+		<path stroke="#c6a0f6" stroke-linecap="round" stroke-linejoin="round" d="M9 3c-.5-.5-1.5-.5-2 0s.5 1.5 1 2.5c.5-1 1.5-2 1-2.5Z" />
+		<path stroke="#eed49f" stroke-linecap="round" stroke-linejoin="round" d="M9 13c-.5.5-1.5.5-2 0s.5-1.5 1-2.5c.5 1 1.5 2 1 2.5Z" />
+		<path stroke="#8bd5ca" stroke-linecap="round" stroke-linejoin="round" d="M3 7c-.5.5-.5 1.5 0 2s1.5-.5 2.5-1c-1-.5-2-1.5-2.5-1Z" />
+		<path stroke="#f5a97f" stroke-linecap="round" stroke-linejoin="round" d="M13 7c.5.5.5 1.5 0 2s-1.5-.5-2.5-1c1-.5 2-1.5 2.5-1Z" />
+		<path stroke="#8aadf4" stroke-linecap="round" stroke-linejoin="round" d="M5.2 3.8c-.7 0-1.4.7-1.4 1.4s1.4.7 2.4 1c-.3-1-.3-2.4-1-2.4Z" />
+		<path stroke="#f5a97f" stroke-linecap="round" stroke-linejoin="round" d="M12.2 10.8c0 .7-.7 1.4-1.4 1.4s-.7-1.4-1-2.4c1 .3 2.4.3 2.4 1Z" />
+		<path stroke="#ed8796" stroke-linecap="round" stroke-linejoin="round" d="M12.2 5.2c0-.7-.7-1.4-1.4-1.4s-.7 1.4-1 2.4c1-.3 2.4-.3 2.4-1Z" />
+		<path stroke="#a6da95" stroke-linecap="round" stroke-linejoin="round" d="M5.2 12.2c-.7 0-1.4-.7-1.4-1.4s1.4-.7 2.4-1c-.3 1-.3 2.4-1 2.4Z" />
+		<circle cx="8" cy="8" r="7" stroke="#a6da95" />
+		<path stroke="#cad3f5" stroke-linejoin="round" d="M7.9 7.9h.2v.2h-.2z" />
+	</g>
+</svg>

--- a/icons/mocha/juce.svg
+++ b/icons/mocha/juce.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+	<g fill="none">
+		<path stroke="#cba6f7" stroke-linecap="round" stroke-linejoin="round" d="M9 3c-.5-.5-1.5-.5-2 0s.5 1.5 1 2.5c.5-1 1.5-2 1-2.5Z" />
+		<path stroke="#f9e2af" stroke-linecap="round" stroke-linejoin="round" d="M9 13c-.5.5-1.5.5-2 0s.5-1.5 1-2.5c.5 1 1.5 2 1 2.5Z" />
+		<path stroke="#94e2d5" stroke-linecap="round" stroke-linejoin="round" d="M3 7c-.5.5-.5 1.5 0 2s1.5-.5 2.5-1c-1-.5-2-1.5-2.5-1Z" />
+		<path stroke="#fab387" stroke-linecap="round" stroke-linejoin="round" d="M13 7c.5.5.5 1.5 0 2s-1.5-.5-2.5-1c1-.5 2-1.5 2.5-1Z" />
+		<path stroke="#89b4fa" stroke-linecap="round" stroke-linejoin="round" d="M5.2 3.8c-.7 0-1.4.7-1.4 1.4s1.4.7 2.4 1c-.3-1-.3-2.4-1-2.4Z" />
+		<path stroke="#fab387" stroke-linecap="round" stroke-linejoin="round" d="M12.2 10.8c0 .7-.7 1.4-1.4 1.4s-.7-1.4-1-2.4c1 .3 2.4.3 2.4 1Z" />
+		<path stroke="#f38ba8" stroke-linecap="round" stroke-linejoin="round" d="M12.2 5.2c0-.7-.7-1.4-1.4-1.4s-.7 1.4-1 2.4c1-.3 2.4-.3 2.4-1Z" />
+		<path stroke="#a6e3a1" stroke-linecap="round" stroke-linejoin="round" d="M5.2 12.2c-.7 0-1.4-.7-1.4-1.4s1.4-.7 2.4-1c-.3 1-.3 2.4-1 2.4Z" />
+		<circle cx="8" cy="8" r="7" stroke="#a6e3a1" />
+		<path stroke="#cdd6f4" stroke-linejoin="round" d="M7.9 7.9h.2v.2h-.2z" />
+	</g>
+</svg>

--- a/src/defaults/fileIcons.ts
+++ b/src/defaults/fileIcons.ts
@@ -1319,6 +1319,9 @@ const fileIcons: FileIcons = {
       '.whitesource',
     ],
   },
+  'juce': {
+    fileExtensions: ['jucer'],
+  },
   'julia': {
     languageIds: ['julia'],
     fileExtensions: ['jl'],


### PR DESCRIPTION
added icon for JUCE c++ audio plugin framework. specifically for xml projucer generated files `.jucer`

[reference](https://juce.com/)
![logo](https://juce.com/wp-content/uploads/2022/07/JUCE-logo-horiz-ondark.png)