### PR TITLE
fix(associations): add `.just` ext, `.justfile` filename for just

### DIFF
--- a/src/defaults/fileIcons.ts
+++ b/src/defaults/fileIcons.ts
@@ -1328,7 +1328,8 @@ const fileIcons: FileIcons = {
     fileExtensions: ['ipynb'],
   },
   'just': {
-    fileNames: ['justfile'],
+    fileExtensions: ['just'],
+    fileNames: ['justfile', '.justfile'],
   },
   'key': {
     fileExtensions: [


### PR DESCRIPTION
Adds the `.just` extension, which is used for Just modules: https://just.systems/man/en/modules1190.html. Also added the missing hidden justfile, `.justfile`.