### PR TITLE
feat(icons): re-include old `css3` icon (unassociated)

### DIFF
--- a/icons/css-variables/css3.svg
+++ b/icons/css-variables/css3.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+	<g fill="none" stroke-linecap="round" stroke-linejoin="round">
+		<path stroke="var(--vscode-ctp-blue)" d="M1.5 1.5h13L13 13l-5 2-5-2z" />
+		<path stroke="var(--vscode-ctp-text)" d="M5 4.5h6l-.5 6-2.5 1-2.5-1-.08-1m1.08-2h4" />
+	</g>
+</svg>

--- a/icons/frappe/css3.svg
+++ b/icons/frappe/css3.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+	<g fill="none" stroke-linecap="round" stroke-linejoin="round">
+		<path stroke="#8caaee" d="M1.5 1.5h13L13 13l-5 2-5-2z" />
+		<path stroke="#c6d0f5" d="M5 4.5h6l-.5 6-2.5 1-2.5-1-.08-1m1.08-2h4" />
+	</g>
+</svg>

--- a/icons/latte/css3.svg
+++ b/icons/latte/css3.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+	<g fill="none" stroke-linecap="round" stroke-linejoin="round">
+		<path stroke="#1e66f5" d="M1.5 1.5h13L13 13l-5 2-5-2z" />
+		<path stroke="#4c4f69" d="M5 4.5h6l-.5 6-2.5 1-2.5-1-.08-1m1.08-2h4" />
+	</g>
+</svg>

--- a/icons/macchiato/css3.svg
+++ b/icons/macchiato/css3.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+	<g fill="none" stroke-linecap="round" stroke-linejoin="round">
+		<path stroke="#8aadf4" d="M1.5 1.5h13L13 13l-5 2-5-2z" />
+		<path stroke="#cad3f5" d="M5 4.5h6l-.5 6-2.5 1-2.5-1-.08-1m1.08-2h4" />
+	</g>
+</svg>

--- a/icons/mocha/css3.svg
+++ b/icons/mocha/css3.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+	<g fill="none" stroke-linecap="round" stroke-linejoin="round">
+		<path stroke="#89b4fa" d="M1.5 1.5h13L13 13l-5 2-5-2z" />
+		<path stroke="#cdd6f4" d="M5 4.5h6l-.5 6-2.5 1-2.5-1-.08-1m1.08-2h4" />
+	</g>
+</svg>


### PR DESCRIPTION
This PR re-introduces the `css3`/css shield icon to give users the option of using the previous default icon.

To revert back to the previous default icon, add the following JSON to your `settings.json`:

```json
"catppuccin-icons.associations.extensions": {
  "css": "css3"
},
"catppuccin-icons.associations.languages": {
  "css": "css3"
},
```

Closes #444