### PR TITLE
feat(associations): `apple-developer-merchantid-domain-association` to `apple` icon

### DIFF
--- a/src/defaults/fileIcons.ts
+++ b/src/defaults/fileIcons.ts
@@ -104,6 +104,7 @@ const fileIcons: FileIcons = {
     fileNames: [
       '.ds_store',
       'apple-app-site-association',
+      'apple-developer-merchantid-domain-association',
     ],
   },
   'asciidoc': {


### PR DESCRIPTION
This PR adds support for `apple-developer-merchantid-domain-association` files

Official documentation : https://developer.apple.com/documentation/applepaywebmerchantregistrationapi/preparing-merchant-domains-for-verification